### PR TITLE
for small screens, centered nav and removed overflow-x

### DIFF
--- a/main.css
+++ b/main.css
@@ -25,9 +25,7 @@ ul {
   background-color: rgb(10, 10, 10);
 }
 
-li {
-  float: left;
-}
+
 
 li a {
   display: block;
@@ -226,11 +224,21 @@ li a:hover {
     filter: url(#noise);
   }
   
-  @media(max-width: 768px) {
+@media(max-width: 768px) {
     #card {
       width: 100%;
     }
-  }
+    #me{
+        margin-left:0;
+        margin-right:0;
+    }
+}
+
+@media (min-width:1024px) {
+    li {
+        float: left;
+    }
+}
   
   *::-webkit-scrollbar,
 *::-webkit-scrollbar-thumb {


### PR DESCRIPTION
Navigation doesn't flow anymore to the left on smaller screens and is centered on phones.
Also, on phones there was an overflow-x because of some styles in `bulma.min.css`. Precisely
```css
.columns{
    margin-left:-0.75rem;
    margin-right:-0.75rem;
}
```
These are now overwritten on the section that has `id=me` by a media query.